### PR TITLE
fix: アクションコンボシステム

### DIFF
--- a/Assets/ScriptableObject/SO_BlownAway.asset
+++ b/Assets/ScriptableObject/SO_BlownAway.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e230353cf528e9b419e39e41e3916914, type: 3}
   m_Name: SO_BlownAway
   m_EditorClassIdentifier: Assembly-CSharp::SC_EnemyBlownAway
-  blownAwayPower: 10
-  blownAwayDirection: {x: 0.045604534, y: 0, z: 0.99895954}
+  blownAwayPower: 35
+  blownAwayDirection: {x: 0.9316322, y: 0, z: 0.36340252}
   endSpeed: 0.1
   decaySpeed: 2
+  uppercutPower: 5

--- a/Assets/Scripts/Enemy/SC_EnemyBlownAway.cs
+++ b/Assets/Scripts/Enemy/SC_EnemyBlownAway.cs
@@ -8,8 +8,9 @@ public class SC_EnemyBlownAway : SC_EnemyBaceState
     [Tooltip("吹き飛ばされる方向"), SerializeField] private Vector3 blownAwayDirection = new Vector3(0, 0, 0);
     [Tooltip("この速度以下で終了"), SerializeField] private float endSpeed = 0.1f;
     [Tooltip("力の減衰速度"), SerializeField] private float decaySpeed = 5f;
-    [Tooltip("アッパーY方向威力"), SerializeField] private float uppercutPower = 10.0f;
-    
+    [Tooltip("アッパー時の横方向速度"), SerializeField] private float uppercutHorizontalSpeed = 8.0f;
+    [Tooltip("アッパー時の上方向速度"), SerializeField] private float uppercutVerticalSpeed = 10.0f;
+
     private AttackType receivedAttackType;
 
     public override void Enter(GameObject Owner, SC_EnemyStatusManager Manager)
@@ -34,13 +35,18 @@ public class SC_EnemyBlownAway : SC_EnemyBaceState
 
         Debug.Log($"Enter dir={blownAwayDirection} power={adjustedPower}");
 
-        Vector3 velocity = blownAwayDirection.normalized * adjustedPower;
+        Vector3 velocity;
 
         // Uppercut の時だけ Y方向を固定値にする
         if (receivedAttackType == AttackType.Uppercut)
         {
             Debug.Log("Uppercut!!");
-           velocity.y = uppercutPower;
+            velocity = blownAwayDirection * uppercutHorizontalSpeed;
+            velocity.y = uppercutVerticalSpeed;
+        }
+        else
+        {
+            velocity = blownAwayDirection.normalized * adjustedPower;
         }
 
         rb.linearVelocity = velocity;

--- a/Assets/Scripts/Player/SC_PlayerAttack.cs
+++ b/Assets/Scripts/Player/SC_PlayerAttack.cs
@@ -239,7 +239,7 @@ public class SC_PlayerAttack : MonoBehaviour
         }
     }
 
-    private void AttackExe(int AttackDamage, Vector3 AreaSize, bool BlowAway, AttackType attackType)
+    private bool AttackExe(int AttackDamage, Vector3 AreaSize, bool BlowAway, AttackType attackType)
     {
         var center = transform.forward * (AreaSize.z * 0.5f) + transform.up * (AreaSize.y * 0.5f) + transform.position;
         int HitCount = Physics.OverlapBoxNonAlloc(
@@ -254,14 +254,17 @@ public class SC_PlayerAttack : MonoBehaviour
         for (int i = 0; i < HitCount; i++)
         {
             var hit = overlapCollision[i];
+
+            if(hit == null) continue;
+
             if (hit.CompareTag("Enemy"))
             {
                 // BlownAway状態の敵にはダメージを与えない
                 SC_EnemyStatusManager enemy = hit.GetComponent<SC_EnemyStatusManager>();
-                if (enemy.IsBlownAway())
-                {
-                    continue;
-                }
+                
+                if(enemy==null) continue;
+                
+                if (enemy.IsBlownAway()) continue;
 
                 enemy.TakeDamage(AttackDamage, transform.position, BlowAway, attackType);
                 hasHitEnemy = true;
@@ -276,6 +279,8 @@ public class SC_PlayerAttack : MonoBehaviour
         {
             currentAttackCooldown = attackCooldown * 0.5f; // 敵に当たらなかった場合はクールダウンを短くするなどの調整も可能
         }
+
+        return hasHitEnemy;
     }
 
     // Scene上でこのオブジェクトが選択されているときに攻撃範囲を可視化
@@ -347,9 +352,17 @@ public class SC_PlayerAttack : MonoBehaviour
             return;
         }
 
-        ExecuteAttackData(attackData);
+        bool hasHitEnemy = ExecuteAttackData(attackData);
 
-        UpdateComboState(inputType, attackData);
+        //攻撃が当たった時だけコンボ計算
+        if (hasHitEnemy)
+        {
+            UpdateComboState(inputType, attackData);
+        }
+        else
+        {
+            ResetCombo();
+        }
     }
 
     //入力変換
@@ -409,14 +422,16 @@ public class SC_PlayerAttack : MonoBehaviour
     }
 
     //アクション実行
-    private void ExecuteAttackData(AttackData attackData)
+    private bool ExecuteAttackData(AttackData attackData)
     {
         Vector3 jumpInSize = scTarget.GetCurrentTarget() != null
             ? TargetingJumpInAreaSize
             : JumpInAreaSize;
 
         JumpInEnemy(jumpInSize, attackData.areaSize);
-        AttackExe(attackData.damage, attackData.areaSize, attackData.blowAway, attackData.attackType);
+        bool hasHitEnemy = AttackExe(attackData.damage, attackData.areaSize, attackData.blowAway, attackData.attackType);
+
+        return hasHitEnemy;
     }
 
     //コンボ状態更新


### PR DESCRIPTION
Missしたら、アクションコンボリセット
uppercutの飛び距離を固定値にする