### PR TITLE
Assets/ExternalAssetsフォルダを追跡しないフォルダに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ Assets/LocalSpace/
 Assets/LocalSpace.meta
 
 Assets/_Recovery/
+
+# External assets that are linked to the project but not stored in the repository
+Assets/ExternalAssets/
+Assets/ExternalAssets.meta


### PR DESCRIPTION
# ExternalAssetsフォルダを追加

## 概要

- `ExternalAssets`フォルダに`テクスチャ` `モデル` `オーディオ`を移行
- パッケージ化して共有しGitHubの管理から除外

## 変更点

- `.gitignore`に`Assets/ExternalAssets/`と`Assets/ExternalAssets.meta`を追加
-

## 備考

- 

## 関連Issue

- Closes #165 
