### PR TITLE
docs: add StateMachene recovery and rebase troubleshooting guide

### DIFF
--- a/docs/troubleshooting/2026-06-11-statemachene-rebase.md
+++ b/docs/troubleshooting/2026-06-11-statemachene-rebase.md
@@ -1,0 +1,248 @@
+# StateMachene 誤コミット除外対応 議事録
+
+## 概要
+
+`feature/BossHP` ブランチの PR に、本来含めるべきではない `Assets/Scripts/Player/StateMachene` 配下の変更が混入していた。
+
+当初は StateMachene フォルダの削除が原因と考えられたが、調査の結果、削除コミットの修正後も PR 差分に StateMachene の変更が残っており、過去コミットに誤って含まれていた変更が原因であることが判明した。
+
+最終的に Interactive Rebase を用いて対象コミットを書き換え、StateMachene の変更を PR から除外した。
+
+---
+
+## 発生していた問題
+
+### GitHub PR 上の状況
+
+* `Files changed` に StateMachene 関連ファイルが表示される
+* PR に不要な変更が混入している
+* Change Files 数が想定より多い（31 Changes）
+
+### 当初の想定
+
+以下のコミットで StateMachene フォルダを誤削除したと考えた。
+
+```text
+feat:BossHP
+```
+
+削除コミットを amend して復元を実施。
+
+---
+
+## 調査内容
+
+### 削除コミットの特定
+
+```bash
+git log --all --diff-filter=D --summary -- Assets/Scripts/Player/StateMachene
+```
+
+削除コミットを発見。
+
+---
+
+### 削除コミット修正
+
+親コミットから復元。
+
+```bash
+git restore \
+  --source=<削除コミット>^ \
+  --staged \
+  --worktree \
+  Assets/Scripts/Player/StateMachene
+```
+
+```bash
+git commit --amend --no-edit
+```
+
+---
+
+### 差分確認
+
+```bash
+git diff HEAD^ HEAD --name-status
+```
+
+結果
+
+```text
+M Assets/Resources/Prefabs/PF_Boss.prefab
+```
+
+削除差分が除去されたことを確認。
+
+---
+
+## 原因調査
+
+しかし GitHub 上では StateMachene の変更が残存。
+
+以下を確認。
+
+```bash
+git log --oneline -- Assets/Scripts/Player/StateMachene
+```
+
+結果
+
+```text
+90530ab feat:BossHP
+```
+
+StateMachene を変更したコミットが存在することを確認。
+
+---
+
+### 対象コミット確認
+
+```bash
+git show --name-status 90530ab
+```
+
+結果
+
+```text
+M Assets/Scripts/Player/StateMachene/SC_PlayerChargeAttack.cs
+M Assets/Scripts/Player/StateMachene/SC_PlayerJumpInState.cs
+M Assets/Scripts/Player/StateMachene/SC_PlayerKnockback.cs
+M Assets/Scripts/Player/StateMachene/SC_PlayerMoveState.cs
+M Assets/Scripts/Player/StateMachene/SC_PlayerStateManager.cs
+M Assets/Scripts/Player/StateMachene/SC_PlayerStrongAttackState.cs
+M Assets/Scripts/Player/StateMachene/SC_PlayerWeakAttackState.cs
+```
+
+原因は削除ではなく、過去の `feat:BossHP` コミットに StateMachene の変更が混入していたことだった。
+
+---
+
+## 対応内容
+
+### Interactive Rebase
+
+対象コミットの親から Rebase 開始。
+
+```bash
+git rebase -i f5a1a27
+```
+
+対象コミットを edit に変更。
+
+```text
+edit 90530ab feat:BossHP
+```
+
+---
+
+### StateMachene を親コミット状態へ戻す
+
+```bash
+git restore \
+  --source=90530ab^ \
+  --staged \
+  --worktree \
+  Assets/Scripts/Player/StateMachene
+```
+
+---
+
+### コミット修正
+
+```bash
+git commit --amend --no-edit
+```
+
+---
+
+### Rebase 完了
+
+```bash
+git rebase --continue
+```
+
+---
+
+## 最終確認
+
+### HEAD確認
+
+```bash
+git show --name-status HEAD
+```
+
+結果
+
+```text
+M Assets/Resources/Prefabs/PF_Boss.prefab
+```
+
+StateMachene の変更が存在しないことを確認。
+
+---
+
+### StateMachene の差分確認
+
+```bash
+git diff <base_commit>..HEAD --name-status | grep StateMachene
+```
+
+結果
+
+```text
+(出力なし)
+```
+
+PR 差分から StateMachene が除外されたことを確認。
+
+---
+
+## GitHub反映
+
+```bash
+git push --force-with-lease origin feature/BossHP
+```
+
+---
+
+## 学び・再発防止
+
+### PR作成前確認
+
+対象ファイルの確認。
+
+```bash
+git diff --name-status <base>..HEAD
+```
+
+### 特定ディレクトリの履歴確認
+
+```bash
+git log --oneline -- <path>
+```
+
+### 特定コミットの変更確認
+
+```bash
+git show --name-status <commit>
+```
+
+### Rebase時の基本手順
+
+1. 対象コミット特定
+2. `git rebase -i`
+3. `edit` 指定
+4. `git restore --source=<parent>`
+5. `git commit --amend`
+6. `git rebase --continue`
+7. `git push --force-with-lease`
+
+---
+
+## 結果
+
+* StateMachene の削除差分を除外
+* StateMachene の誤変更差分を除外
+* PR 差分を本来必要な変更のみに整理
+* GitHub PR 上の不要な差分を解消


### PR DESCRIPTION
# StateMachene誤変更の調査・復旧手順を追加

## 概要

- StateMachene配下の変更が意図せずPRへ混入した際の調査および復旧手順をドキュメント化
- Interactive Rebase を用いたコミット修正手順を記録
- 今後同様の問題が発生した場合のナレッジとして共有

## 変更点

- StateMachene変更混入時の調査手順を追加
- 削除コミットの特定方法を追加
- `git log` を利用した変更コミットの特定方法を追加
- `git rebase -i` によるコミット修正手順を追加
- `git restore` を利用した不要変更の除外手順を追加
- `git commit --amend` および `git rebase --continue` の実施手順を追加
- GitHubへの反映方法（force push）を追加
- 再発防止のための確認コマンドを追加

## 備考

- StateMacheneフォルダの削除が原因ではなく、過去コミット（90530ab）に変更が混入していたことが原因
- Interactive Rebase により不要な変更をコミットから除外
- PR差分から StateMachene の変更が除外されたことを確認済み

## 関連Issue

- Closes #173 